### PR TITLE
fix: replace halo with yaspin

### DIFF
--- a/fief_client/integrations/cli.py
+++ b/fief_client/integrations/cli.py
@@ -258,7 +258,7 @@ class FiefAuth:
         except queue.Empty as e:
             raise FiefAuthAuthorizationCodeMissingError() from e
 
-        spinner.write = "Getting a token..."
+        spinner.text = "Getting a token..."
 
         tokens, userinfo = self.client.auth_callback(
             code, redirect_uri, code_verifier=code_verifier

--- a/fief_client/integrations/cli.py
+++ b/fief_client/integrations/cli.py
@@ -10,7 +10,8 @@ import typing
 import urllib.parse
 import webbrowser
 
-from halo import Halo
+from yaspin import yaspin
+from yaspin.spinners import Spinners
 
 from fief_client import (
     Fief,
@@ -233,8 +234,9 @@ class FiefAuth:
         )
         webbrowser.open(authorization_url)
 
-        spinner = Halo(
-            text="Please complete authentication in your browser.", spinner="dots"
+        spinner = yaspin(
+            text="Please complete authentication in your browser.",
+            spinner=Spinners.dots,
         )
         spinner.start()
 
@@ -256,14 +258,14 @@ class FiefAuth:
         except queue.Empty as e:
             raise FiefAuthAuthorizationCodeMissingError() from e
 
-        spinner.text = "Getting a token..."
+        spinner.write = "Getting a token..."
 
         tokens, userinfo = self.client.auth_callback(
             code, redirect_uri, code_verifier=code_verifier
         )
         self._save_credentials(tokens, userinfo)
 
-        spinner.succeed("Successfully authenticated")
+        spinner.ok("Successfully authenticated")
 
         return tokens, userinfo
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
   "pytest-mock",
   "respx",
   "ruff",
+  "yaspin",
   "uvicorn[standard]",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ module = "jwcrypto.*"
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
-module = "halo.*"
+module = "yaspin.*"
 ignore_missing_imports = true
 
 [tool.ruff]
@@ -47,7 +47,6 @@ dependencies = [
   "pytest-mock",
   "respx",
   "ruff",
-  "yaspin",
   "uvicorn[standard]",
 ]
 
@@ -114,7 +113,7 @@ flask = [
 ]
 
 cli = [
-  "halo",
+  "yaspin",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Description

Fixes #18 
This is a change to [fief-python](https://github.com/fief-dev/fief-python/tree/28b2dd61add4f69aef8db7204d64cba0f0627914)

Halo is used to produce the spinner in the cli and IPython. This causes an error, and since halo is no longer maintained, we have replaced halo with yaspin